### PR TITLE
Pip installable!

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,13 +63,22 @@ parallel --willcite --tty --header : tv -w 60 -urls http://himawari8-dl.nict.go.
 
 It is just a single-file script so all you'll need to do it put it in your `PATH`.
 
-Dependencies are Python 3, GDAL 2.0, and Numpy. To install these dependencies on a Mac with [homebrew](http://brew.sh) do:
+Dependencies are Python 3, GDAL 2.0, and Numpy.
+
+To install these dependencies on a Mac with [homebrew](http://brew.sh) do:
 ```
 brew install gdal --with-complete --without-python --HEAD
 brew install python3
-pip3 install numpy gdal
+pip3 install -e git+https://github.com/daleroberts/tv
 ```
-On Linux, I typically install GDAL 2.0 by hand-compiling it.
+
+On Ubuntu Linux do:
+```
+sudo apt install python3 libgdal-dev
+export CPLUS_INCLUDE_PATH=/usr/include/gdal
+export C_INCLUDE_PATH=/usr/include/gdal
+pip3 install -e git+https://github.com/daleroberts/tv
+```
 
 ### Does it work on Windows using PuTTY?
 

--- a/tv.py
+++ b/tv.py
@@ -263,7 +263,8 @@ def show_url(url, *args, **kwargs):
         gdal.Unlink(mmapfn)
 
 
-if __name__ == '__main__':
+def main():
+    global RESET, QUANT, CHARS, MASKS, SAMPLING, RE_URL, NEWLINE, LVLS256, SNAP256
     import argparse
     parser = argparse.ArgumentParser()
     parser.add_argument('-w', type=int, default=shutil.get_terminal_size()[0])
@@ -314,3 +315,7 @@ if __name__ == '__main__':
 
     except KeyboardInterrupt:
         print(RESET.decode('utf-8'))
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
Just added a `setup.py` so that you can use `pip` to install tv, and automatically get numpy the python GDAL bindings. Currently have the instructions install from github, but this will of course allow you to publish tv to PyPi (and the name tv doesn't seem taken yet!)